### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -2,6 +2,8 @@
 
 name: CI
 
+permissions:
+  contents: read
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch


### PR DESCRIPTION
Potential fix for [https://github.com/nivlawest1911-oss/Tiffany-ED/security/code-scanning/1](https://github.com/nivlawest1911-oss/Tiffany-ED/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow, specifying the minimum required permissions for the GITHUB_TOKEN. Since the workflow only checks out code and runs local scripts, it typically needs read-only access to repository contents. Add the `permissions` block at the workflow root, before the `jobs:` section (so it applies to all jobs unless overridden). The only necessary permission is `contents: read`. 

Edit the file `.github/workflows/blank.yml`, and insert:

```yaml
permissions:
  contents: read
```

directly after the `name: CI` block (e.g. after line 4), and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
